### PR TITLE
再生時に曲名を表示するように #44

### DIFF
--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -64,7 +64,7 @@ class App extends React.Component<Props, State> {
             const currentTrack = state.track_window.current_track;
             const artists = currentTrack.artists.map(v => v.name).join(", ");
 
-            document.title = `${currentTrack.name}・${artists}`;
+            document.title = `${currentTrack.name} · ${artists}`;
         }
     };
 

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -57,6 +57,15 @@ class App extends React.Component<Props, State> {
         this.setState({
             state: state,
         });
+
+        if (state.paused) {
+            document.title = "Littlify";
+        } else {
+            const currentTrack = state.track_window.current_track;
+            const artists = currentTrack.artists.map(v => v.name).join(", ");
+
+            document.title = `${currentTrack.name}・${artists}`;
+        }
     };
 
     injectSpotifyEvents = ({ refreshToken }: { refreshToken: string }) => {


### PR DESCRIPTION
Resolved #44 
現状、Spotify Web Playerと同じ動作・表示を行うようにしてあります。
再生時は「曲名・アーティスト」、停止時は「Littlify」と表示されます。
問題があれば修正します 🙇