### PR TITLE
Spotifyのリンクを開けるようにした #20

### DIFF
--- a/packages/client/src/component/Player.tsx
+++ b/packages/client/src/component/Player.tsx
@@ -8,7 +8,6 @@ import SpotifyURILink from "./SpotifyURILink";
 import Shortcut from "./shortcut";
 import Controller from "./Controller";
 import Artists from "./Artists";
-import { url } from "inspector";
 
 interface Props {
     state: Spotify.PlaybackState;

--- a/packages/client/src/component/Player.tsx
+++ b/packages/client/src/component/Player.tsx
@@ -47,10 +47,21 @@ export default class Player extends React.Component<Props, {}> {
             const matches = text.match(regex);
             if (!matches) continue;
 
-            const spotifyUri = `spotify:${matches[1]}:${matches[2]}`;
+            const type = matches[1];
+            const id = matches[2];
+
+            const spotifyUri = `spotify:${type}:${id}`;
             let data = {};
 
-            switch (matches[1]) {
+            if (spotifyUri === this.props.state.context.uri) return;
+
+            if (
+                type === "track" &&
+                spotifyUri === this.props.state.track_window.current_track.uri
+            )
+                return;
+
+            switch (type) {
                 case "album":
                 case "artist":
                 case "playlist":

--- a/packages/client/src/component/Player.tsx
+++ b/packages/client/src/component/Player.tsx
@@ -38,39 +38,41 @@ export default class Player extends React.Component<Props, {}> {
         const text = e.dataTransfer.getData("text");
         if (!text) return;
 
-        const matches = text.match(
-            /^https:\/\/open\.spotify.com\/(\w+)\/(\w+)\/?/
-        );
+        const regexes = [
+            /^https:\/\/open\.spotify.com\/(\w+)\/(\w+)\/?/,
+            /^spotify:(\w+):(\w+)$/,
+        ];
 
-        if (!matches) return;
+        for (const regex of regexes) {
+            const matches = text.match(regex);
+            if (!matches) continue;
 
-        const uri = `spotify:${matches[1]}:${matches[2]}`;
-        let data = {};
+            const spotifyUri = `spotify:${matches[1]}:${matches[2]}`;
+            let data = {};
 
-        switch (matches[1]) {
-            case "algum":
-            case "artist":
-            case "playlist":
-                data = {
-                    context_uri: uri,
-                };
-                break;
-            case "track":
-                data = {
-                    uris: [uri],
-                };
-                break;
-            default:
-                return;
-        }
+            switch (matches[1]) {
+                case "album":
+                case "artist":
+                case "playlist":
+                    data = {
+                        context_uri: spotifyUri,
+                    };
+                    break;
+                case "track":
+                    data = {
+                        uris: [spotifyUri],
+                    };
+                    break;
+                default:
+                    return;
+            }
 
-        axios
-            .put(`https://api.spotify.com/v1/me/player/play`, data, {
+            axios.put(`https://api.spotify.com/v1/me/player/play`, data, {
                 headers: {
                     Authorization: `Bearer ${this.props.accessToken}`,
                 },
-            })
-            .then(response => console.log(response));
+            });
+        }
     }
 
     render() {

--- a/packages/client/src/component/Player.tsx
+++ b/packages/client/src/component/Player.tsx
@@ -51,6 +51,12 @@ export default class Player extends React.Component<Props, {}> {
             const id = matches[2];
 
             const spotifyUri = `spotify:${type}:${id}`;
+
+            if (type === "track") {
+                this.addToQueue(spotifyUri);
+                return;
+            }
+
             let data = {};
 
             if (spotifyUri === this.props.state.context.uri) return;
@@ -84,6 +90,20 @@ export default class Player extends React.Component<Props, {}> {
                 },
             });
         }
+    }
+
+    addToQueue(spotifyUri: string) {
+        console.log("addToQueue");
+
+        axios.post(
+            `https://api.spotify.com/v1/me/player/add-to-queue?uri=${spotifyUri}`,
+            {},
+            {
+                headers: {
+                    Authorization: `Bearer ${this.props.accessToken}`,
+                },
+            }
+        );
     }
 
     render() {

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -182,6 +182,7 @@ class App extends React.Component<Props, State> {
                         <Player
                             state={this.state.state}
                             player={this.state.player}
+                            accessToken={this.state.accessToken}
                         />
                     ) : (
                         <NoStateScreen />

--- a/packages/server/src/routes/v1/index.ts
+++ b/packages/server/src/routes/v1/index.ts
@@ -13,9 +13,12 @@ router.get("/login", (req, res) => {
     const state = req.query.state;
     res.cookie(stateKey, state);
 
-    const scope = ["streaming", "user-read-email", "user-read-private"].join(
-        " "
-    );
+    const scope = [
+        "streaming",
+        "user-read-email",
+        "user-read-private",
+        "user-modify-playback-state",
+    ].join(" ");
 
     res.redirect(
         "https://accounts.spotify.com/authorize?" +


### PR DESCRIPTION
Resolved #20 

Spotifyのリンクを開けるようにしました。
アーティスト・アルバムの場合は即時再生しますが、トラックの場合のみ次に再生するようにしてあります。
`/v1/me/player/play`にトラックを投げてしまうと、曲が終わっても自動再生が行われず再生が止まってしまうのでこのような動作にしました。

また、`/v1/me/player/add-to-queue`を利用するためにスコープに`user-modify-playback-state`を追加したため既存ユーザーは再認証が必要となります。
