### PR TITLE
アイコンにFeatherを使用する

### DIFF
--- a/packages/client/.stylelintrc
+++ b/packages/client/.stylelintrc
@@ -12,6 +12,7 @@
         ],
         "block-no-empty": null,
         "unit-whitelist": [
+            "px",
             "em",
             "rem",
             "s"

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -27,10 +27,6 @@
         "typescript": "^3.7.5"
     },
     "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^1.2.27",
-        "@fortawesome/free-brands-svg-icons": "^5.12.1",
-        "@fortawesome/free-solid-svg-icons": "^5.12.1",
-        "@fortawesome/react-fontawesome": "^0.1.8",
         "autoprefixer": "^9.7.4",
         "axios": "^0.19.2",
         "classnames": "^2.2.6",
@@ -40,6 +36,7 @@
         "query-string": "^6.10.1",
         "react": "^16.12.0",
         "react-dom": "^16.12.0",
+        "react-feather": "^2.0.3",
         "react-router-dom": "^5.1.2",
         "sass": "^1.25.0",
         "tailwindcss": "^1.2.0",

--- a/packages/client/src/component/Config.tsx
+++ b/packages/client/src/component/Config.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import classNames from "classnames";
-import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { ChevronDown } from "react-feather";
 
 export enum Theme {
     AUTO = "AUTO",
@@ -86,7 +85,7 @@ export default class Config extends React.Component<{}, State> {
                             </select>
                             {/**/}
                             <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
-                                <FontAwesomeIcon icon={faCaretDown} />
+                                <ChevronDown size={16} />
                             </div>
                         </div>
                     </label>

--- a/packages/client/src/component/Controller.tsx
+++ b/packages/client/src/component/Controller.tsx
@@ -1,14 +1,13 @@
 import React from "react";
 import classNames from "classnames";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-    faCaretLeft,
-    faCaretRight,
-    faPause,
-    faPlay,
-    faSlidersH,
-} from "@fortawesome/free-solid-svg-icons";
-import { faTwitter } from "@fortawesome/free-brands-svg-icons";
+    Play,
+    Pause,
+    ChevronLeft,
+    ChevronRight,
+    Sliders,
+    Twitter,
+} from "react-feather";
 
 import ExternalLink from "./ExternalLink";
 import { State as IConfig, Theme } from "./Config";
@@ -76,7 +75,7 @@ export default class Controller extends React.Component<Props, {}> {
                 <div
                     className={classNames(
                         "flex-1",
-                        "py-3",
+                        "py-4",
                         "hover:text-gray-500",
                         "dark:hover:text-gray-600"
                     )}
@@ -89,7 +88,7 @@ export default class Controller extends React.Component<Props, {}> {
                         this.props.player.seek(0);
                     }}
                 >
-                    <FontAwesomeIcon icon={faCaretLeft} />
+                    <ChevronLeft className={classNames("m-auto")} size={16} />
                 </div>
                 <div
                     className={classNames(
@@ -103,15 +102,21 @@ export default class Controller extends React.Component<Props, {}> {
                     }}
                 >
                     {state.paused ? (
-                        <FontAwesomeIcon icon={faPlay} />
+                        <Play
+                            className={classNames("m-auto", "filled")}
+                            size={20}
+                        />
                     ) : (
-                        <FontAwesomeIcon icon={faPause} />
+                        <Pause
+                            className={classNames("m-auto", "filled")}
+                            size={20}
+                        />
                     )}
                 </div>
                 <div
                     className={classNames(
                         "flex-1",
-                        "py-3",
+                        "py-4",
                         "hover:text-gray-500",
                         "dark:hover:text-gray-600"
                     )}
@@ -119,12 +124,12 @@ export default class Controller extends React.Component<Props, {}> {
                         this.props.player?.nextTrack();
                     }}
                 >
-                    <FontAwesomeIcon icon={faCaretRight} />
+                    <ChevronRight className={classNames("m-auto")} size={16} />
                 </div>
                 <div
                     className={classNames(
                         "flex-1",
-                        "py-3",
+                        "py-4",
                         "hover:text-gray-500",
                         "dark:hover:text-gray-600"
                     )}
@@ -132,12 +137,15 @@ export default class Controller extends React.Component<Props, {}> {
                         window.open("/config");
                     }}
                 >
-                    <FontAwesomeIcon icon={faSlidersH} />
+                    <Sliders
+                        className={classNames("m-auto")}
+                        size={16}
+                    />
                 </div>
                 <ExternalLink
                     className={classNames(
                         "flex-none",
-                        "py-3",
+                        "py-4",
                         "px-8",
                         "hover:text-gray-500",
                         "dark:hover:text-gray-600"
@@ -146,7 +154,10 @@ export default class Controller extends React.Component<Props, {}> {
                         `${track.name}\r\n${track.artists[0].name} - ${track.album.name}\r\nhttps://open.spotify.com/track/${track.id}`
                     )}`}
                 >
-                    <FontAwesomeIcon icon={faTwitter} />
+                    <Twitter
+                        className={classNames("m-auto", "filled")}
+                        size={16}
+                    />
                 </ExternalLink>
             </div>
         );

--- a/packages/client/src/component/Controller.tsx
+++ b/packages/client/src/component/Controller.tsx
@@ -61,10 +61,9 @@ export default class Controller extends React.Component<Props, {}> {
         return (
             <div
                 className={classNames(
-                    "controll-column",
+                    "controller-column",
                     "flex",
                     "items-center",
-                    "text-center",
                     "select-none",
                     "bg-gray-200",
                     "border-t",
@@ -74,8 +73,6 @@ export default class Controller extends React.Component<Props, {}> {
             >
                 <div
                     className={classNames(
-                        "flex-1",
-                        "py-4",
                         "hover:text-gray-500",
                         "dark:hover:text-gray-600"
                     )}
@@ -88,12 +85,10 @@ export default class Controller extends React.Component<Props, {}> {
                         this.props.player.seek(0);
                     }}
                 >
-                    <ChevronLeft className={classNames("m-auto")} size={16} />
+                    <ChevronLeft size={16} />
                 </div>
                 <div
                     className={classNames(
-                        "flex-1",
-                        "py-3",
                         "hover:text-gray-500",
                         "dark:hover:text-gray-600"
                     )}
@@ -102,21 +97,13 @@ export default class Controller extends React.Component<Props, {}> {
                     }}
                 >
                     {state.paused ? (
-                        <Play
-                            className={classNames("m-auto", "filled")}
-                            size={20}
-                        />
+                        <Play className={classNames("filled")} size={20} />
                     ) : (
-                        <Pause
-                            className={classNames("m-auto", "filled")}
-                            size={20}
-                        />
+                        <Pause className={classNames("filled")} size={20} />
                     )}
                 </div>
                 <div
                     className={classNames(
-                        "flex-1",
-                        "py-4",
                         "hover:text-gray-500",
                         "dark:hover:text-gray-600"
                     )}
@@ -124,12 +111,10 @@ export default class Controller extends React.Component<Props, {}> {
                         this.props.player?.nextTrack();
                     }}
                 >
-                    <ChevronRight className={classNames("m-auto")} size={16} />
+                    <ChevronRight size={16} />
                 </div>
                 <div
                     className={classNames(
-                        "flex-1",
-                        "py-4",
                         "hover:text-gray-500",
                         "dark:hover:text-gray-600"
                     )}
@@ -137,15 +122,12 @@ export default class Controller extends React.Component<Props, {}> {
                         window.open("/config");
                     }}
                 >
-                    <Sliders
-                        className={classNames("m-auto")}
-                        size={16}
-                    />
+                    <Sliders size={16} />
                 </div>
                 <ExternalLink
                     className={classNames(
                         "flex-none",
-                        "py-4",
+                        "h-full",
                         "px-8",
                         "hover:text-gray-500",
                         "dark:hover:text-gray-600"
@@ -154,10 +136,7 @@ export default class Controller extends React.Component<Props, {}> {
                         `${track.name}\r\n${track.artists[0].name} - ${track.album.name}\r\nhttps://open.spotify.com/track/${track.id}`
                     )}`}
                 >
-                    <Twitter
-                        className={classNames("m-auto", "filled")}
-                        size={16}
-                    />
+                    <Twitter className={classNames("filled")} size={16} />
                 </ExternalLink>
             </div>
         );

--- a/packages/client/src/style/index.css
+++ b/packages/client/src/style/index.css
@@ -3,3 +3,7 @@
 @import "tailwindcss/components";
 
 @import "tailwindcss/utilities";
+
+.filled {
+    fill: currentColor;
+}

--- a/packages/client/src/style/index.css
+++ b/packages/client/src/style/index.css
@@ -7,3 +7,14 @@
 .filled {
     fill: currentColor;
 }
+
+.controller-column {
+    height: 50px;
+}
+.controller-column > div {
+    @apply flex-1 h-full;
+}
+.controller-column > div > svg,
+.controller-column > a > svg {
+    @apply h-full m-auto;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -805,39 +805,6 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@fortawesome/fontawesome-common-types@^0.2.27":
-  version "0.2.27"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.27.tgz#19706345859fc46adf3684ed01d11b40903b87e9"
-  integrity sha512-97GaByGaXDGMkzcJX7VmR/jRJd8h1mfhtA7RsxDBN61GnWE/PPCZhOdwG/8OZYktiRUF0CvFOr+VgRkJrt6TWg==
-
-"@fortawesome/fontawesome-svg-core@^1.2.27":
-  version "1.2.27"
-  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.27.tgz#e4db8e3be81a40988213507c3e3d0c158a6641a3"
-  integrity sha512-sOD3DKynocnHYpuw2sLPnTunDj7rLk91LYhi2axUYwuGe9cPCw7Bsu9EWtVdNJP+IYgTCZIbyARKXuy5K/nv+Q==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.27"
-
-"@fortawesome/free-brands-svg-icons@^5.12.1":
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.12.1.tgz#67977addd15e21e57aa1ed71cd2ddecdfaa88647"
-  integrity sha512-IYUYcgGsQuwiIHjRGfeSTCIQKUSZMb6FsV6mDj78K0D+YzGJkM4cvEBBUMHtnla5D2HCxncMI/9JX5YIk2GHeQ==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.27"
-
-"@fortawesome/free-solid-svg-icons@^5.12.1":
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.12.1.tgz#76b6f958a3471821ff146f8f955e6d7cfe87147c"
-  integrity sha512-k3MwRFFUhyL4cuCJSaHDA0YNYMELDXX0h8JKtWYxO5XD3Dn+maXOMrVAAiNGooUyM2v/wz/TOaM0jxYVKeXX7g==
-  dependencies:
-    "@fortawesome/fontawesome-common-types" "^0.2.27"
-
-"@fortawesome/react-fontawesome@^0.1.8":
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.8.tgz#cb6d4dd3aeec45b6ff2d48c812317a6627618511"
-  integrity sha512-I5h9YQg/ePA3Br9ISS18fcwOYmzQYDSM1ftH03/8nHkiqIVHtUyQBw482+60dnzvlr82gHt3mGm+nDUp159FCw==
-  dependencies:
-    prop-types "^15.5.10"
-
 "@iarna/toml@^2.2.0":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
@@ -7053,7 +7020,7 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7249,6 +7216,13 @@ react-dom@^16.12.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
     scheduler "^0.18.0"
+
+react-feather@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-2.0.3.tgz#1453ff5d8c242f72b8c02846118fbd2d406375ad"
+  integrity sha512-XVjtxIyMxb2RFlqC2APoB/IZvXKDW9uLN1c264XEeZNYe8jIxjQVQpeTo3nxtHiLTgMfgf0ZYxJC6HwmY8+9BA==
+  dependencies:
+    prop-types "^15.7.2"
 
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.12.0"


### PR DESCRIPTION
FontAwesomeのFree版で使えるアイコンが少なく今後の機能追加に差し支えるので、オープンで使用したいアイコンが一通り揃っていそうな[Feather](https://feathericons.com/)に変更します。

close #13 

具体的には普通の大きさのボリュームアイコンがFree版では使えないためです。
https://fontawesome.com/icons?d=gallery&q=volume&s=solid

![image](https://user-images.githubusercontent.com/3516343/76145535-81c5af80-60cd-11ea-9bb4-0367fdf5bd33.png)

上: 変更後（Feather）
下: 変更前（FontAwesome）

## 容量の削減

FontAwesomeを使うとTree Shakingしない場合すべてのアイコンをjsの中に収めるので容量が大きくなりますが、featherは比較的小さいので容量の肥大化を抑えられます。

### FontAwesome
```
dist\src.9307386b.js                 ‼  1.34 MB    20.09s
```
### Feather
```
dist\src.bc861578.js                  667.16 KB    1.49s
```

Tree ShakingできるならしたほうがいいのはもちろんですがParcelだと難しそう（？）

----
追記

ビルドオプションに--experimental-scope-hoistingつけるだけでTree Shakingできるみたいなの試しました

### FontAwesome
```
dist\src.3ed7bec0.js                  204.52 KB    19.40s
```
### Feather
```
dist\src.e10b5483.js                  242.84 KB    16.90s
```

ほぼ変わらんうえにFontAwesomeに負けたが