### PR TITLE
切断時にtitleが元に戻らない問題を修正 #52

### DIFF
--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -59,7 +59,7 @@ class App extends React.Component<Props, State> {
             state: state,
         });
 
-        if (state.paused) {
+        if (!state || state.paused) {
             document.title = "Littlify";
         } else {
             const currentTrack = state.track_window.current_track;


### PR DESCRIPTION
Fixed #52 
切断時の処理が漏れていました、すみません。
元に戻るように修正しました。