### PR TITLE
PurgeCSS追加 #55

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "client:lint:fix": "yarn client:lint --fix",
         "client:start": "yarn workspace client start",
         "client:watch": "yarn workspace client watch",
+        "client:clean": "yarn workspace client clean",
         "lint": "run-p client:lint server:lint",
         "lint:fix": "run-p client:lint:fix server:lint:fix",
         "server:build": "yarn workspace server build",
@@ -33,7 +34,8 @@
         "husky": "^4.2.3",
         "lint-staged": "^10.0.7",
         "npm-run-all": "^4.1.5",
-        "prettier": "^1.19.1"
+        "prettier": "^1.19.1",
+        "shx": "^0.3.2"
     },
     "lint-staged": {
         "packages/{client,server}/src/**/*.{js,jsx,ts,tsx}": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -7,13 +7,15 @@
         "postcss:watch": "postcss src/style/index.css --output src/index.css --watch",
         "postcss:build": "postcss src/style/index.css --output src/index.css",
         "parcel:serve": "parcel src/index.html",
-        "parcel:build": "parcel build src/index.html --no-source-maps",
+        "parcel:build": "NODE_ENV=production parcel build src/index.html --no-source-maps",
         "watch": "run-s postcss:build watch:all",
         "watch:all": "run-p postcss:watch parcel:serve",
         "start": "run-s postcss:build parcel:serve",
-        "build": "run-s postcss:build parcel:build"
+        "build": "run-s postcss:build parcel:build",
+        "clean": "shx rm -rf .cache dist src/index.css"
     },
     "devDependencies": {
+        "@fullhuman/postcss-purgecss": "^2.1.0",
         "@types/classnames": "^2.2.9",
         "@types/node": "^13.7.1",
         "@types/react": "^16.9.19",

--- a/packages/client/postcss.config.js
+++ b/packages/client/postcss.config.js
@@ -1,6 +1,17 @@
 module.exports = {
     plugins: [
         require("tailwindcss")("./tailwind.config.js"),
-        require("autoprefixer")
+        require("autoprefixer"),
+        require("@fullhuman/postcss-purgecss")({
+            content: [
+                "./index.html",
+                "./src/**/*.css",
+                "./src/**/*.ts",
+                "./src/**/*.tsx"
+            ],
+            whitelistPatternsChildren: [
+                /.*theme-dark.*/,
+            ],
+        }),
     ]
 };

--- a/packages/client/src/component/Controller.tsx
+++ b/packages/client/src/component/Controller.tsx
@@ -32,10 +32,12 @@ export default class Controller extends React.Component<Props, {}> {
 
         switch (config.theme) {
             case Theme.DARK:
-                document.documentElement.dataset["theme"] = "dark";
+                document.documentElement.classList.remove("theme-light");
+                document.documentElement.classList.add("theme-dark");
                 break;
             case Theme.LIGHT:
-                document.documentElement.dataset["theme"] = "light";
+                document.documentElement.classList.add("theme-light");
+                document.documentElement.classList.remove("theme-dark");
                 break;
             default:
                 // REF: https://github.com/ChanceArthur/tailwindcss-dark-mode/blob/master/prefers-dark.js
@@ -48,9 +50,11 @@ export default class Controller extends React.Component<Props, {}> {
                         window.matchMedia("(prefers-color-scheme: dark)")
                             .matches
                     );
-                    document.documentElement.dataset["theme"] = "dark";
+                    document.documentElement.classList.remove("theme-light");
+                    document.documentElement.classList.add("theme-dark");
                 } else {
-                    document.documentElement.dataset["theme"] = "light";
+                    document.documentElement.classList.add("theme-light");
+                    document.documentElement.classList.remove("theme-dark");
                 }
         }
     }

--- a/packages/client/tailwind.config.js
+++ b/packages/client/tailwind.config.js
@@ -1,6 +1,6 @@
 module.exports = {
     theme: {
-        darkSelector: 'html[data-theme="dark"]',
+        darkSelector: ".theme-dark",
         extend: {
             maxWidth: {
                 "screen-1/2": "50vw"

--- a/yarn.lock
+++ b/yarn.lock
@@ -805,6 +805,14 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@fullhuman/postcss-purgecss@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.1.0.tgz#955fc2e3f69b0d0c84367eeee4f85c01238a65dc"
+  integrity sha512-zmV+cK8pAo/suKMQk1fKzDdols5ltOy86Hk51qwkiJJt4olm3t1MaUrm4U4MlA9fiYeRpLqsNop2xNoEm8DV+w==
+  dependencies:
+    postcss "7.0.27"
+    purgecss "^2.1.0"
+
 "@iarna/toml@^2.2.0":
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.3.tgz#f060bf6eaafae4d56a7dac618980838b0696e2ab"
@@ -2346,7 +2354,7 @@ commander@^2.11.0, commander@^2.17.1, commander@^2.19.0, commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.1:
+commander@^4.0.0, commander@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -3228,6 +3236,11 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
+es6-object-assign@^1.0.3:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
+  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
+
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -3967,7 +3980,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -4554,6 +4567,11 @@ internal-slot@^1.0.2:
     es-abstract "^1.17.0-next.1"
     has "^1.0.3"
     side-channel "^1.0.2"
+
+interpret@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
+  integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
@@ -6922,6 +6940,15 @@ postcss@6.0.1:
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
+postcss@7.0.27:
+  version "7.0.27"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.27.tgz#cc67cdc6b0daa375105b7c424a85567345fc54d9"
+  integrity sha512-WuQETPMcW9Uf1/22HWUWP9lgsIC+KEHg2kozMflKjbeUtw9ujvFX6QmIfozaErDkmLWS9WEnEdEe6Uo9/BNTdQ==
+  dependencies:
+    chalk "^2.4.2"
+    source-map "^0.6.1"
+    supports-color "^6.1.0"
+
 postcss@^6.0.1, postcss@^6.0.9:
   version "6.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.23.tgz#61c82cc328ac60e677645f979054eb98bc0e3324"
@@ -7118,6 +7145,16 @@ purgecss@^1.4.0:
     postcss "^7.0.14"
     postcss-selector-parser "^6.0.0"
     yargs "^14.0.0"
+
+purgecss@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-2.1.0.tgz#6da655d166073824efe2532b0c6466c740d939d6"
+  integrity sha512-QnXhowNjeWo9vNnGES2LVzDXdRR/8EvG/O03m4bYOWfAX0ShmG/Pmj7brVtVBy2eaaRAmNy23L+GBc4SpDFUeQ==
+  dependencies:
+    commander "^4.0.0"
+    glob "^7.0.0"
+    postcss "7.0.27"
+    postcss-selector-parser "^6.0.2"
 
 q@^1.1.2:
   version "1.5.1"
@@ -7339,6 +7376,13 @@ readdirp@~3.3.0:
   integrity sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==
   dependencies:
     picomatch "^2.0.7"
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
 
 redent@^3.0.0:
   version "3.0.0"
@@ -7623,7 +7667,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.5, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.3.2, resolve@^1.4.0:
+resolve@^1.1.5, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.3.2, resolve@^1.4.0:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
@@ -7916,6 +7960,24 @@ shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
+
+shelljs@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
+
+shx@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.2.tgz#40501ce14eb5e0cbcac7ddbd4b325563aad8c123"
+  integrity sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==
+  dependencies:
+    es6-object-assign "^1.0.3"
+    minimist "^1.2.0"
+    shelljs "^0.8.1"
 
 side-channel@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
1. PurgeCSSを導入
2. clientのbuildに `NODE_ENV=production` を追加してparcelのminifyを有効化
3. yarn cleanできるように[shx](https://github.com/shelljs/shx)を追加

備考:
datasetが使えないようなのでhtmlにtheme-hogeなクラスを付与するように変更しています。
https://github.com/FullHuman/purgecss/issues/277